### PR TITLE
Fix convert weights to pb errors

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -114,7 +114,7 @@ def bboxes_giou(boxes1, boxes2):
     
     left_up_min = np.minimum(boxes1[..., :2], boxes2[..., :2])
     right_down_max = np.maximum(boxes1[..., 2:], boxes2[..., 2:])
-    c_area left_up_min * right_down_max
+    c_area = left_up_min * right_down_max
 
     giou_term = (c_area - union_area) / c_area
     return iou - giou_term

--- a/core/yolov3.py
+++ b/core/yolov3.py
@@ -38,7 +38,7 @@ class YOLOV3(object):
     def __build_nework(self, input_data):
         assert self.net_type in ['darknet53', 'mobilenetv2']
 
-        if self.net_type == 'darknet53'
+        if self.net_type == 'darknet53':
             route_1, route_2, input_data = backbone.darknet53(input_data, self.trainable)
 
             input_data = common.convolutional(input_data, (1, 1, 1024, 512), self.trainable, 'conv52')

--- a/scripts/from_darknet_weights_to_ckpt.py
+++ b/scripts/from_darknet_weights_to_ckpt.py
@@ -1,6 +1,5 @@
 import numpy as np
 import tensorflow as tf
-from core.yolov3 import YOLOV3
 from core.yolov4 import YOLOV4
 
 

--- a/scripts/from_darknet_weights_to_pb.py
+++ b/scripts/from_darknet_weights_to_pb.py
@@ -1,5 +1,4 @@
 import tensorflow as tf
-from core.yolov3 import YOLOV3
 from core.yolov4 import YOLOV4
 from from_darknet_weights_to_ckpt import load_weights
 


### PR DESCRIPTION
Missing equal sign
https://github.com/avBuffer/Yolov5_tf/blob/682db0d61af10bcdd80cfd1362cdf3f92a447e4a/core/utils.py#L117

Missing colon
https://github.com/avBuffer/Yolov5_tf/blob/682db0d61af10bcdd80cfd1362cdf3f92a447e4a/core/yolov3.py#L41

Removed Yolov3 import from convert script as they are not used.